### PR TITLE
challenge: freeze the flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Nonetheless, feel free to contact **Valix Consulting** for your smart contract c
 | 7  | The Secret Source  |
 | 8  | Trick or Thieve  |
 | 10  | Alice in The Dark  |
+| 11  | Freeze The Flow  |
 
 # How to play
 1. Clone this repository

--- a/contracts/freeze-the-flow/README.md
+++ b/contracts/freeze-the-flow/README.md
@@ -1,0 +1,6 @@
+# Fleeze The Flow Challenge
+There is an ether vault with depositors. Users can deposit and withdraw their funds, but they must use the VaultHelper contract for these transactions. 
+
+The VaultHelper contract acts as a gateway to the vault and cannot receive any ether.
+
+To pass the challenge, your have to disable the deposit feature of the VaultHelper contract.

--- a/contracts/freeze-the-flow/Vault.sol
+++ b/contracts/freeze-the-flow/Vault.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract Vault is Ownable{
+    address public vaultHelpaer;
+    mapping(address => uint256) private balance;
+
+    event Deposit(address sender, uint256 amount);
+    event Withdraw(address sender, uint256 amount);
+    event SetVaultHelper(address prevVaultHelper, address newVaultHelper);
+
+    modifier onlyVaultHelper() {
+        require(msg.sender == address(vaultHelpaer), "Only VaultHelper can call to this action");
+        _;
+    }
+
+    function deposit(address _to) external payable onlyVaultHelper {
+        require(_to != address(0), "Invalid address");
+        require(msg.value > 0, "No deposit");
+        balance[_to] += msg.value;
+
+        emit Deposit(_to, msg.value);
+    }
+
+    function withdraw(address _to, uint256 _amount) external onlyVaultHelper {
+        require(_to != address(0), "Invalid address");
+        require(_amount > 0, "Amount withdraw should above zero");
+
+        require(balance[_to] >= _amount);
+        balance[_to] -= _amount;
+        payable(_to).transfer(_amount);
+
+        emit Withdraw(_to, _amount);
+    }
+
+    function setVaultHelper(address _newVaultHelper) external onlyOwner{
+        address prevVaultHelper = address(vaultHelpaer);
+        vaultHelpaer = _newVaultHelper;
+
+        emit SetVaultHelper(prevVaultHelper, _newVaultHelper);
+    }
+
+    function getUserBalance(address _user) public view returns(uint256){
+        return balance[_user];
+    }
+    
+    function getVaultBalance() public view returns(uint256){
+        return address(this).balance;
+    }
+}

--- a/contracts/freeze-the-flow/Vault.sol
+++ b/contracts/freeze-the-flow/Vault.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract Vault is Ownable{
+contract Vault is Ownable {
     address public vaultHelpaer;
     mapping(address => uint256) private balance;
 
@@ -35,18 +35,18 @@ contract Vault is Ownable{
         emit Withdraw(_to, _amount);
     }
 
-    function setVaultHelper(address _newVaultHelper) external onlyOwner{
+    function setVaultHelper(address _newVaultHelper) external onlyOwner {
         address prevVaultHelper = address(vaultHelpaer);
         vaultHelpaer = _newVaultHelper;
 
         emit SetVaultHelper(prevVaultHelper, _newVaultHelper);
     }
 
-    function getUserBalance(address _user) public view returns(uint256){
+    function getUserBalance(address _user) public view returns(uint256) {
         return balance[_user];
     }
     
-    function getVaultBalance() public view returns(uint256){
+    function getVaultBalance() public view returns(uint256) {
         return address(this).balance;
     }
 }

--- a/contracts/freeze-the-flow/VaultHelper.sol
+++ b/contracts/freeze-the-flow/VaultHelper.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "./Vault.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract VaultHelper is Ownable{
+contract VaultHelper is Ownable {
 
     Vault public vault;
         
@@ -34,7 +34,7 @@ contract VaultHelper is Ownable{
         vault.withdraw(_user, _amount);
     }
 
-    function setVaultHelper(address _newVault) external onlyOwner{
+    function setVaultHelper(address _newVault) external onlyOwner {
         address prevVault = address(vault);
         vault = Vault(_newVault);
 

--- a/contracts/freeze-the-flow/VaultHelper.sol
+++ b/contracts/freeze-the-flow/VaultHelper.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import "./Vault.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract VaultHelper is Ownable{
+
+    Vault public vault;
+        
+    event SetVault(address prevVault, address newVault);
+
+    constructor(Vault _vault) {
+        vault = _vault;
+    }
+    
+    function depositToVault(
+        address _user
+    ) external payable {
+        require(msg.sender == _user, "Sender can only deposit for self");
+        require(msg.value > 0, "No forwarded deposited value");
+        require(_user != address(0), "Invalid Address");
+        vault.deposit{value: msg.value}(_user);
+
+        require(address(this).balance == 0);
+    }
+
+    function withdrawFromVault(
+        address _user,
+        uint256 _amount
+    ) external payable {
+        require(msg.sender == _user, "Sender can only withdraw for self");
+        require(_user != address(0), "Invalid Address");
+        vault.withdraw(_user, _amount);
+    }
+
+    function setVaultHelper(address _newVault) external onlyOwner{
+        address prevVault = address(vault);
+        vault = Vault(_newVault);
+
+        emit SetVault(prevVault, _newVault);
+    }
+
+    receive() external payable { revert(); }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "bullied-boy": "npx hardhat test test/bullied-boy/bullied-boy.challenge.ts",
         "the-secret-source": "npx hardhat test test/the-secret-source/the-secret-source.challenge.ts",
         "trick-or-thieve": "npx hardhat test test/trick-or-thieve/trick-or-thieve.challenge.ts",
-        "alice-in-the-dark": "npx hardhat test test/alice-in-the-dark/alice-in-the-dark.challenge.ts"
+        "alice-in-the-dark": "npx hardhat test test/alice-in-the-dark/alice-in-the-dark.challenge.ts",
+        "freeze-the-flow": "npx hardhat test test/freeze-the-flow/freeze-the-flow.challenge.ts"
     },
     "devDependencies": {
         "hardhat": "2.17.1",

--- a/test/freeze-the-flow/freeze-the-flow.challenge.ts
+++ b/test/freeze-the-flow/freeze-the-flow.challenge.ts
@@ -1,0 +1,60 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import { Vault } from '../../typechain-types';
+import { VaultHelper } from '../../typechain-types';
+
+describe('Challenge - Fleeze The Flow', function () {
+    let deployer: SignerWithAddress;
+    let player: SignerWithAddress;
+    let someUser: SignerWithAddress;
+
+    let vault: Vault;
+    let vaultHelper: VaultHelper;
+
+    before(async function () {
+        /** SETUP SCENARIO - NO NEED TO CHANGE ANYTHING HERE */
+        [deployer, player, someUser] = await ethers.getSigners();
+
+        // Deploy VaultHelper & Vault Contracts
+        const Vault = await (await ethers.getContractFactory('Vault', deployer));
+        vault = await Vault.deploy();
+
+        const VaultHelper = await (await ethers.getContractFactory('VaultHelper', deployer));
+        vaultHelper = await VaultHelper.deploy(vault.address);
+
+        await vault.setVaultHelper(vaultHelper.address);
+
+        expect(await vault.owner()).to.eq(deployer.address);
+        expect(await vaultHelper.owner()).to.eq(deployer.address);
+
+        expect(await vault.vaultHelpaer()).to.eq(vaultHelper.address);
+        expect(await vaultHelper.vault()).to.eq(vault.address);
+
+        // someUser interact with the Vault contract through VaultHelper contract;
+        await vaultHelper.connect(someUser).depositToVault(someUser.address, { value: ethers.utils.parseEther("100") });
+        expect(await vault.getUserBalance(someUser.address)).to.eq(ethers.utils.parseEther("100"));
+        expect(await vault.getVaultBalance()).to.eq(ethers.utils.parseEther("100"));
+
+        // someUser cannot directly interact to Vault contract
+        await expect(vault.connect(someUser).deposit(someUser.address, { value: ethers.utils.parseEther("100") })).to.be.reverted;
+        // someUser cannot directly send ether to VaultHelper contract
+        await expect(someUser.sendTransaction({
+            to: vaultHelper.address,
+            value: ethers.utils.parseEther("100"),
+        })).to.be.reverted;
+    });
+
+    it('Execution', async function () {
+        /** CODE YOUR SOLUTION HERE */
+        
+    });
+
+    after(async function () {
+        /** SUCCESS CONDITIONS - NO NEED TO CHANGE ANYTHING HERE */
+
+        // Player has stopped the deposit process
+        await expect(vaultHelper.connect(someUser).depositToVault(someUser.address, { value: ethers.utils.parseEther("100") })).to.be.reverted;
+    });
+});


### PR DESCRIPTION
# Fleeze The Flow Challenge
There is an ether vault with depositors. Users can deposit and withdraw their funds, but they must use the VaultHelper contract for these transactions. 

The VaultHelper contract acts as a gateway to the vault and cannot receive any ether.

To pass the challenge, your have to disable the deposit feature of the VaultHelper contract.
